### PR TITLE
replace dots with underscores in property names

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+2.2.2 / 2017-03-17
+==================
+
+  * Replace dots with underscores in property names
+
 2.2.2 / 2017-03-03
 ==================
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -31,6 +31,10 @@ exports.track = function(track, settings) {
   props.keen.timestamp = track.timestamp();
   var ret = {};
 
+  // We have to ensure that none of the property names have
+  // unsupported characters.
+  props = normalize(props);
+
   extend(props, {
     userId: track.userId() || track.sessionId(),
     page_url: track.proxy('properties.url') || track.proxy('context.page.url'),
@@ -50,3 +54,17 @@ exports.track = function(track, settings) {
   ret[track.event()] = [props];
   return ret;
 };
+
+function normalize(event) {
+  var normalizedEvent = { };
+  for (var name in event) {
+    if (event.hasOwnProperty(name)) {
+      normalizedEvent[normalizeName(name)] = event[name];
+    }
+  }
+  return normalizedEvent;
+}
+
+function normalizeName(name) {
+  return name.replace('.', '_');
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration-keen-io",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "Keen IO server-side integration",
   "author": "Segment <friends@segment.com>",
   "repository": {

--- a/test/fixtures/traits.json
+++ b/test/fixtures/traits.json
@@ -5,7 +5,10 @@
     "type": "track",
     "timestamp": "2014",
     "properties": {
-      "url": "https://segment.io/docs"
+      "url": "https://segment.io/docs",
+      "payload.instanceId": null,
+      "payload.instanceSize": null,
+      "payload.taskDomain": "t2medium"
     },
     "context": {
       "userAgent": "user-agent",
@@ -26,6 +29,9 @@
       "user_agent": "user-agent",
       "page_url": "https://segment.io/docs",
       "url": "https://segment.io/docs",
+      "payload_instanceId": null,
+      "payload_instanceSize": null,
+      "payload_taskDomain": "t2medium",
       "traits": {
         "user-name": "user-name"
       },


### PR DESCRIPTION
This should fix the issues we're seeing where Keen.io denies the events because properties include dots.

Please take a look and let me know if you have any concerns.